### PR TITLE
fix: Add explicit workflow permissions

### DIFF
--- a/.github/workflows/integrations-tests.yml
+++ b/.github/workflows/integrations-tests.yml
@@ -6,7 +6,10 @@ on:
       - main
   schedule:
    - cron: '0 9 * * *'
-  
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Sets GitHub Actions workflow permissions to 'read' only (explicit).