### PR TITLE
Fix providing version directly

### DIFF
--- a/.github/workflows/integrations-tests.yml
+++ b/.github/workflows/integrations-tests.yml
@@ -62,7 +62,7 @@ jobs:
       graylog_end_of_life: "${{ steps.graylog.outputs.end_of_life }}"
       graylog_version: "${{ steps.graylog.outputs.version }}"
       python_end_of_life: "${{ steps.python.outputs.end_of_life }}"
-      python_version: "${{ steps.python.outputs.version}}"
+      python_version: "${{ steps.python.outputs.version }}"
 
   assert:
     runs-on: ubuntu-latest

--- a/.github/workflows/integrations-tests.yml
+++ b/.github/workflows/integrations-tests.yml
@@ -47,6 +47,12 @@ jobs:
           product: 'azure-kubernetes-service'
           file_path: '__fixtures__/variables.tf'
           regex: '(?<=default = \")([^\"]+)'
+      - uses: ./
+        name: Python (Version)
+        id: python
+        with:
+          product: python
+          version: 2.7
 
     outputs:
       prometheus_end_of_life: "${{ steps.prometheus.outputs.end_of_life }}"
@@ -55,6 +61,8 @@ jobs:
       grafana_version: "${{ steps.grafana.outputs.version }}"
       graylog_end_of_life: "${{ steps.graylog.outputs.end_of_life }}"
       graylog_version: "${{ steps.graylog.outputs.version }}"
+      python_end_of_life: "${{ steps.python.outputs.end_of_life }}"
+      python_version: "${{ steps.python.outputs.version}}"
 
   assert:
     runs-on: ubuntu-latest
@@ -90,3 +98,13 @@ jobs:
         with:
           expected: 'v5.2.12'
           actual: "${{ needs.test.outputs.graylog_version }}"
+      - name: Assert Python EoL
+        uses: nick-fields/assert-action@v2
+        with:
+          expected: 'true'
+          actual: "${{ needs.test.outputs.python_end_of_life }}"
+      - name: Assert Python extracted version
+        uses: nick-fields/assert-action@v2
+        with:
+          expected: '2.7'
+          actual: "${{ needs.test.outputs.python_version }}"

--- a/src/get_cycle.py
+++ b/src/get_cycle.py
@@ -198,25 +198,27 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    if not args.file_path and not args.version:
-        sys.exit("Either file_path or version must be provided.")
+    # If version is supplied it supersedes others
+    if not args.version:
+        if not args.file_path:
+            sys.exit("Either file_path or version must be provided.")
 
-    if args.file_path and not (args.file_key or args.regex):
-        sys.exit(
-            "Either file_key or regex must be provided when extracting from file.")
+        if args.file_path and not (args.file_key or args.regex):
+            sys.exit(
+                "Either file_key or regex must be provided when extracting from file.")
 
-    if args.file_key and args.regex:
-        sys.exit("Only one of file_key or regex can be provided.")
+        if args.file_key and args.regex:
+            sys.exit("Only one of file_key or regex can be provided.")
 
-    if args.regex:
-        try:
-            re.compile(args.regex)
-        except re.error:
-            sys.exit(f"Invalid regular expression: '{args.regex}'")
-        args.file_format = "text"
+        if args.regex:
+            try:
+                re.compile(args.regex)
+            except re.error:
+                sys.exit(f"Invalid regular expression: '{args.regex}'")
+            args.file_format = "text"
 
-    if args.file_format not in ['yaml', 'json'] and not args.regex:
-        sys.exit("A regex must be provided when using text format.")
+        if args.file_format not in ['yaml', 'json'] and not args.regex:
+            sys.exit("A regex must be provided when using text format.")
 
     result = get_product_cycle(args)
     if not result:


### PR DESCRIPTION
When using the Python script directly, instead of the Action, it will error because no file format is given.
```
$ python ./src/get_cycle.py --product python --version 2.7
A regex must be provided when using text format.
```

This doesn't happen when using the action because a default file type of _yaml_ is given.
https://github.com/sindrel/endoflife-github-action/blob/6931ca61221cebfe107b0c3349979cb7075ff270/action.yml#L19-L22

The other options are not used when the version is defined, as seen in the _get_product_cycle_ function below, so duplicating that logic on the option validation fixes the issue.
https://github.com/sindrel/endoflife-github-action/blob/6931ca61221cebfe107b0c3349979cb7075ff270/src/get_cycle.py#L19-L29